### PR TITLE
[Bin] add timestamp, engine option for test_localization

### DIFF
--- a/bin/test_localization.py
+++ b/bin/test_localization.py
@@ -4,11 +4,29 @@ import argparse
 import subprocess
 import os
 import logging
+from datetime import datetime
 
 PROJECT_HOME = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 RUN_DOCKER_SCRIPT = os.path.join(PROJECT_HOME, 'bin/run-docker.py')
 OUT_DIR = os.path.join(PROJECT_HOME, 'localizer-outs')
+ENGINE_LIST = ('tarantula', 'prophet')
 bug_dict = {}
+timestamp = ''
+
+except_case_list = (  # build failure cases list
+        '2011-01-06-7c6310852e-3571c955b5', '2011-02-19-356b619487-a3a5157286',
+        '2011-03-20-2034e14341-7f2937223d', '2011-03-25-8138f7de40-3acdca4703',
+        '2011-03-26-3acdca4703-c2fe893985', '2011-04-06-18d71a6f59-187eb235fe',
+        '2011-04-07-77ed819430-efcb9a71cd', '2011-04-08-efcb9a71cd-6f3148db81',
+        '2011-04-30-9c285fddbb-93f65cdeac', '2011-05-13-db0c957f02-8ba00176f1',
+        '2011-05-17-453c954f8a-daecb2c0f4', '2011-05-21-f5a9e17f9c-964f44a280',
+        '2011-05-24-b60f6774dc-1056c57fa9', '2011-10-30-c1a4a36c14-5921e73a37',
+        '2011-10-31-2e5d5e5ac6-b5f15ef561', '2011-11-01-735efbdd04-e0f781f496',
+        '2011-11-01-ceac9dc490-9b0d73af1d', '2011-11-01-d2881adcbc-4591498df7',
+        '2011-11-02-c1d520d19d-9b86852d6e', '2011-11-02-de50e98a07-8d520d6296',
+        '2011-11-04-9da01ac6b6-7334dfd7eb', '2011-11-15-236120d80e-fb37f3b20d',
+        '2011-11-16-55acfdf7bd-3c7a573a2c', '2011-11-23-eca88d3064-db0888dfc1',
+        '2011-12-04-b3ad0b7af7-1d6c98a136')
 
 logging.basicConfig(
     level=logging.INFO,
@@ -17,9 +35,14 @@ logging.basicConfig(
     datefmt="%H:%M:%S")
 
 
-def init():
+def init(args):
     if not os.path.isdir(OUT_DIR):
         os.mkdir(OUT_DIR)
+    global timestamp
+    if args.timestamp:
+        timestamp = args.timestamp
+    else:
+        timestamp = datetime.today().strftime('%Y%m%d-%H:%M:%S')
     bugzoo_process = subprocess.run(['bugzoo', 'bug', 'list'],
                                     capture_output=True,
                                     text=True)
@@ -29,6 +52,8 @@ def init():
         _, case, _, _, _, installed, _ = list(
             map(lambda s: s.strip(), bug.split('|')))
         case = case.split(':')
+        if case[2] in except_case_list:
+            continue
         if case[1] in bug_dict:
             bug_dict[case[1]][case[2]] = installed
         else:
@@ -41,24 +66,16 @@ def build_one(project, case):
     else:
         build_process = subprocess.run(
             ['bugzoo', 'bug', 'build', f'manybugs:{project}:{case}'])
-        build_process.check_returncode()
+        try:
+            build_process.check_returncode()
+        except subprocess.CalledProcessError:
+            logging.error(f'{project}:{case} is already installed. Skip')
+            return False
         logging.info(f'{project}:{case} is successfully installed')
+    return True
 
 
-def build(project, case):
-    if project:
-        if case:
-            build_one(project, case)
-        else:
-            for case in bug_dict[project]:
-                build_one(project, case)
-    else:
-        for project in bug_dict:
-            for case in bug_dict[project]:
-                build_one(project, case)
-
-
-def run_one_localizer(project, case):
+def run_one_localizer(project, case, engine):
     cmd = [f'{RUN_DOCKER_SCRIPT}', f'{project}-{case}', '-d']
     run_docker = subprocess.run(cmd)
     run_docker.check_returncode()
@@ -79,7 +96,7 @@ def run_one_localizer(project, case):
     # TODO: -skip_compile
     localizer_cmd = [
         'docker', 'exec', '-it', f'{docker_id}',
-        '/bugfixer/localizer/main.exe', '/experiment'
+        '/bugfixer/localizer/main.exe', '-engine', engine, '/experiment'
     ]
     localizer = subprocess.run(localizer_cmd)
     try:
@@ -87,9 +104,12 @@ def run_one_localizer(project, case):
     except subprocess.CalledProcessError:
         logging.error(f'{project}:{case} localizer execution failure')
         return
+    out_dir_case = os.path.join(OUT_DIR, project, f'{project}:{case}')
+    os.makedirs(out_dir_case, exist_ok=True)
+    out_dir_timestamp = os.path.join(out_dir_case, timestamp + '-' + engine)
     cp_cmd = [
         'docker', 'cp', f'{docker_id}:/experiment/localizer-out',
-        f'{OUT_DIR}/{project}:{case}'
+        out_dir_timestamp
     ]
     run_cp = subprocess.run(cp_cmd)
     try:
@@ -112,27 +132,44 @@ def run_one_localizer(project, case):
         logging.error(f'Cannot remove docker continer of {project}:{case}')
 
 
-def run_localizer(project, case):
+def build_and_run(args):
+    project, case, engine = args.project, args.case, args.engine
     if project:
         if case:
-            run_one_localizer(project, case)
+            if build_one(project, case):
+                if engine:
+                    run_one_localizer(project, case, engine)
+                else:
+                    for engine in ENGINE_LIST:
+                        run_one_localizer(project, case, engine)
         else:
             for case in bug_dict[project]:
-                run_one_localizer(project, case)
+                if build_one(project, case):
+                    if engine:
+                        run_one_localizer(project, case, engine)
+                    else:
+                        for engine in ENGINE_LIST:
+                            run_one_localizer(project, case, engine)
     else:
         for project in bug_dict:
             for case in bug_dict[project]:
-                run_one_localizer(project, case)
+                if build_one(project, case):
+                    if engine:
+                        run_one_localizer(project, case, engine)
+                    else:
+                        for engine in ENGINE_LIST:
+                            run_one_localizer(project, case, engine)
 
 
 def main():
     parser = argparse.ArgumentParser(description='Build bugs using BugZoo.')
+    parser.add_argument('-t', '--timestamp', type=str)
     parser.add_argument('-p', '--project', type=str)
     parser.add_argument('-c', '--case', type=str)
+    parser.add_argument('-e', '--engine', type=str)
     args = parser.parse_args()
-    init()
-    build(args.project, args.case)
-    run_localizer(args.project, args.case)
+    init(args)
+    build_and_run(args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
timestamp, engine 옵션을 추가하였습니다.
engine 옵션은 특별히 지정하게 되면 해당 engine으로 localization을 실행하며, 지정하지 않으면 dummy를 제외하고 가능한 모든 엔진으로 localization을 한 번씩 실행합니다.
timestamp가 추가되면서 localizer-outs 디렉토리 구조가 아래와 같이 변경되었습니다.

> localizer-outs/[프로젝트이름]/[ManyBugs bug 이름]/[시간]-[engine 이름]/

예를 들어, `./bin/test_localization.py -p php -c 2011-01-09-7c6310852e-478e5d1dd0 -e dummy` 를 실행하면

> localizer-outs/php/php:2011-01-09-7c6310852e-478e5d1dd0/[시간]-dummy/

디렉토리 안에 localization 실행 결과인 log.txt와 result.txt가 생성됩니다.

추가로, bugzoo bug build부터 실패하는 케이스들은 임시방편으로 except_case_list에 모아둬 시도조차 안 하게끔 하였습니다.
추후 문제점을 확인하고 해결하는 경우 삭제할 예정입니다.