### PR TITLE
[Script] add docker_rm.py script to remove docker container easily

### DIFF
--- a/script/docker_rm.py
+++ b/script/docker_rm.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import subprocess
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('project', type=str)
+    args = parser.parse_args()
+    p = args.project
+    ps_cmd = ['docker', 'ps']
+    ps = subprocess.run(ps_cmd, capture_output=True, text=True, check=True)
+    containers = list(
+        map(lambda line: line.split(),
+            ps.stdout.split('\n')[1:-1]))
+    for c in containers:
+        if f'prosyslab/manybugs:{p}' in c[1]:
+            stop_cmd = ['docker', 'stop', f'{c[0]}']
+            stop = subprocess.run(stop_cmd, check=True)
+            rm_cmd = ['docker', 'rm', f'{c[0]}']
+            rm = subprocess.run(rm_cmd, check=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
여러 localizer 구현중 디버깅 과정에서 도커 컨테이너가 계속 남게 돼 이를 일괄 삭제할 수 있는 스크립트를 작성하였습니다.
사용법은 아래와 같습니다.

`./script/docker_rm.py gmp` 을 실행하면, `prosyslab/manybugs:gmp`로 시작하는 모든 도커 컨테이너를 삭제합니다.
`./script/docker_rm.py gmp-14166-14167` 을 실행하면, `prosyslab/manybugs:gmp-14166-14167`로 시작하는 모든도커  컨테이너를 삭제합니다.