### PR TITLE
[Bin] add option to run the bic docker

### DIFF
--- a/bin/run-docker.py
+++ b/bin/run-docker.py
@@ -74,7 +74,16 @@ def run_docker(args, program, bug_id):
         cmd.append('--rm')
     if args.detached:
         cmd.append('-d')
-    cmd += ['prosyslab/manybugs:{}-{}'.format(program, bug_id), '/bin/bash']
+
+    if args.bic:
+        cmd += [
+            'prosyslab/manybugs-differential:{}-{}'.format(program, bug_id),
+            '/bin/bash'
+        ]
+    else:
+        cmd += [
+            'prosyslab/manybugs:{}-{}'.format(program, bug_id), '/bin/bash'
+        ]
     subprocess.run(cmd)
 
 
@@ -83,6 +92,7 @@ def main():
     parser.add_argument('--rm', action='store_true')
     parser.add_argument('-d', action='store_true', dest='detached')
     parser.add_argument('--timestamp', type=str)
+    parser.add_argument('--bic', type=str)
     parser.add_argument('target', type=str)
     args = parser.parse_args()
     initialize(args)


### PR DESCRIPTION
앞으로 BIC 버전의 도커 이미지들을 다음과 같은 네이밍 컨벤션으로 관리하게 되었습니다.
prosyslab/manybugs:[project-case] 의 BIC 버전 -> prosyslab/manybugs-differential:[project-case]

이제 run-docker.py를 통해서 BIC 버전의 도커 이미지를 띄우고 싶다면 --bic 옵션을 주면 됩니다.
--bic 옵션이 주어지지 않는다면 기존처럼 원본 도커 이미지를 띄우게 됩니다.